### PR TITLE
Improve error handling

### DIFF
--- a/mapnik/mapnik.go
+++ b/mapnik/mapnik.go
@@ -4,6 +4,7 @@ package mapnik
 import "C"
 
 import (
+	"errors"
 	"unsafe"
 )
 
@@ -51,8 +52,15 @@ func NewMap(width, height uint32) *Map {
 	return &Map{C.mapnik_map(C.uint(width), C.uint(height))}
 }
 
-func (m *Map) Load(stylesheet string) {
-	C.mapnik_map_load(m.m, C.CString(stylesheet))
+func (m *Map) lastError() error {
+	return errors.New("mapnik: " + C.GoString(C.mapnik_map_last_error(m.m)))
+}
+
+func (m *Map) Load(stylesheet string) error {
+	if C.mapnik_map_load(m.m, C.CString(stylesheet)) != 0 {
+		return m.lastError()
+	}
+	return nil
 }
 
 func (m *Map) Resize(width, height uint32) {
@@ -72,8 +80,11 @@ func (m *Map) SetSRS(srs string) {
 	C.mapnik_map_set_srs(m.m, C.CString(srs))
 }
 
-func (m *Map) ZoomAll() {
-	C.mapnik_map_zoom_all(m.m)
+func (m *Map) ZoomAll() error {
+	if C.mapnik_map_zoom_all(m.m) != 0 {
+		return m.lastError()
+	}
+	return nil
 }
 
 func (m *Map) ZoomToMinMax(minx, miny, maxx, maxy float64) {
@@ -82,16 +93,22 @@ func (m *Map) ZoomToMinMax(minx, miny, maxx, maxy float64) {
 	C.mapnik_map_zoom_to_box(m.m, bbox)
 }
 
-func (m *Map) RenderToFile(path string) {
-	C.mapnik_map_render_to_file(m.m, C.CString(path))
+func (m *Map) RenderToFile(path string) error {
+	if C.mapnik_map_render_to_file(m.m, C.CString(path)) != 0 {
+		return m.lastError()
+	}
+	return nil
 }
 
-func (m *Map) RenderToMemoryPng() []byte {
+func (m *Map) RenderToMemoryPng() ([]byte, error) {
 	i := C.mapnik_map_render_to_image(m.m)
+	if i == nil {
+		return nil, m.lastError()
+	}
 	defer C.mapnik_image_free(i)
 	b := C.mapnik_image_to_png_blob(i)
 	defer C.mapnik_image_blob_free(b)
-	return C.GoBytes(unsafe.Pointer(b.ptr), C.int(b.len))
+	return C.GoBytes(unsafe.Pointer(b.ptr), C.int(b.len)), nil
 }
 
 func (m *Map) Projection() Projection {


### PR DESCRIPTION
I tried to improve the error handling by adding `error` as a return value for most functions.
It requires `mapnik_map_last_error` see: https://github.com/springmeyer/mapnik-c-api/pull/5

It's still a work in progress:
- [ ] `mapnik_map_last_error` needs to be merged in mapnik-c-api
- [ ] errors in the `RegisterXXX` functions should be handled as well
- [ ] add tests
